### PR TITLE
Follow redirects with curl in stackato-setup.sh

### DIFF
--- a/stackato-setup.sh
+++ b/stackato-setup.sh
@@ -15,7 +15,7 @@ if ! [ -s $HOME/index.php ]
 
     # download required files
     echo "Downloading Drush and Drupal..."
-    curl -sfS $DRUSH | tar xzf - 
+    curl -LsS $DRUSH | tar xzf -
     mv drush $SAR
 
     $SAR/drush/drush dl drupal --drupal-project-rename=drupal --yes
@@ -23,7 +23,7 @@ if ! [ -s $HOME/index.php ]
     rmdir drupal
 
     echo "Downloading SMPT module..."
-    curl -sfS $SMTP_MODULE | tar xzf -
+    curl -LsS $SMTP_MODULE | tar xzf -
     mv smtp $SAR/app/modules/smtp
 fi
 


### PR DESCRIPTION
App currently doesn't deploy because the resource URLs are HTTP,
and now redirect to HTTPS instead of serving outright.

curl will follow these with the -L option.
